### PR TITLE
Update Makefile and Workfows from ECR

### DIFF
--- a/.github/workflows/dev-build-workflow.yml
+++ b/.github/workflows/dev-build-workflow.yml
@@ -1,0 +1,23 @@
+### This is the Terraform-generated dev-build.yml workflow for the alma-patronload-dev   ###
+### app repository. If the container requires any additional pre-build commands,         ###
+### uncomment and edit the PREBUILD line at the end of the document.                     ###
+name: Dev Container Build and Deploy
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  deploy:
+    name: Dev Container Deploy
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-dev.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE: "alma-patronload-gha-dev"
+      ECR: "alma-patronload-dev"
+      # FUNCTION: ""
+      # PREBUILD: 

--- a/.github/workflows/prod-promote-workflow.yml
+++ b/.github/workflows/prod-promote-workflow.yml
@@ -1,0 +1,21 @@
+### This is the Terraform-generated prod-promote.yml workflow for the alma-patronload-prod repository. ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document.         ###
+name: Prod Container Promote
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Prod Container Promote
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-promote-prod.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE_STAGE: alma-patronload-gha-stage
+      GHA_ROLE_PROD: alma-patronload-gha-prod
+      ECR_STAGE: "alma-patronload-stage"
+      ECR_PROD: "alma-patronload-prod"
+      # FUNCTION: ""
+ 

--- a/.github/workflows/stage-build-workflow.yml
+++ b/.github/workflows/stage-build-workflow.yml
@@ -1,0 +1,24 @@
+### This is the Terraform-generated dev-build.yml workflow for the alma-patronload-stage app repository ###
+### If this is a Lambda repo, uncomment the FUNCTION line at the end of the document     ###
+### If the container requires any additional pre-build commands, uncomment and edit      ###
+### the PREBUILD line at the end of the document.                                        ###
+name: Stage Container Build and Deploy
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  deploy:
+    name: Stage Container Deploy
+    uses: mitlibraries/.github/.github/workflows/ecr-shared-deploy-stage.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE: "alma-patronload-gha-stage"
+      ECR: "alma-patronload-stage"
+      # FUNCTION: ""
+      # PREBUILD: 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+### This is the Terraform-generated header for alma-patronload-dev. If  ###
+###   this is a Lambda repo, uncomment the FUNCTION line below  ###
+###   and review the other commented lines in the document.     ###
+ECR_NAME_DEV:=alma-patronload-dev
+ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/alma-patronload-dev
+# FUNCTION_DEV:=
+### End of Terraform-generated header                            ###
 SHELL=/bin/bash
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
 
@@ -38,3 +45,33 @@ pylama:
 safety:
 	pipenv check
 	pipenv verify
+
+
+### Terraform-generated Developer Deploy Commands for Dev environment           ###
+dist-dev: ## Build docker container (intended for developer-based manual build)
+	docker build --platform linux/amd64 \
+	    -t $(ECR_URL_DEV):latest \
+		-t $(ECR_URL_DEV):`git describe --always` \
+		-t $(ECR_NAME_DEV):latest .
+
+publish-dev: dist-dev ## Build, tag and push (intended for developer-based manual publish)
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_DEV)
+	docker push $(ECR_URL_DEV):latest
+	docker push $(ECR_URL_DEV):`git describe --always`
+
+
+### Terraform-generated manual shortcuts for deploying to Stage. This requires  ###
+###   that ECR_NAME_STAGE, ECR_URL_STAGE, and FUNCTION_STAGE environment        ###
+###   variables are set locally by the developer and that the developer has     ###
+###   authenticated to the correct AWS Account. The values for the environment  ###
+###   variables can be found in the stage_build.yml caller workflow.            ###
+dist-stage: ## Only use in an emergency
+	docker build --platform linux/amd64 \
+	    -t $(ECR_URL_STAGE):latest \
+		-t $(ECR_URL_STAGE):`git describe --always` \
+		-t $(ECR_NAME_STAGE):latest .
+
+publish-stage: ## Only use in an emergency
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_STAGE)
+	docker push $(ECR_URL_STAGE):latest
+	docker push $(ECR_URL_STAGE):`git describe --always`


### PR DESCRIPTION
### What does this PR do?

* Update Makefile with developer commands to simplify the method for pushing a copy of the container to the ECR repository in our dev AWS account
* Create three caller workflows that leverage our shared container publishing workflows in our GitHub organization.

### Helpful background context

This repository will use an ECR repository in AWS to store the container for the task and will publish the container automatically via GitHub Actions. The changes here include Makefile commands for the application developer to build the container and push it to the ECR repository in Dev1 and the GitHub Actions workflows that will handle the stage publishing and prod promotion of the container.

### How can a reviewer manually see the effects of these changes?

The developer can run the new `make dist-dev` and `make publish-dev` from the local CLI to verify that these commands will build the container and push the container to the ECR repository in Dev1.

Manual testing of the workflows is difficult until they are merged to the `main` branch. The `dev-build` workflow should run automatically, but it won't be available for a manual run until after it's in `main`.

### Includes new or updated dependencies?

NO

### What are the relevant tickets?

* [IN-647](https://mitlibraries.atlassian.net/browse/IN-647)

### Developer

- [X] All new ENV is documented in README (or there is none)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes


[IN-647]: https://mitlibraries.atlassian.net/browse/IN-647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ