### PR TITLE
change ID type from "additional" to "MIT ID"

### DIFF
--- a/config/staff_template.xml
+++ b/config/staff_template.xml
@@ -61,7 +61,7 @@
   <is_researcher>false</is_researcher>
   <user_identifiers>
     <user_identifier segment_type="External">
-      <id_type desc="Additional">02</id_type>
+      <id_type desc="MIT ID">02</id_type>
       <value></value>
       <status>ACTIVE</status>
     </user_identifier>

--- a/config/student_template.xml
+++ b/config/student_template.xml
@@ -66,7 +66,7 @@
   <is_researcher></is_researcher>
   <user_identifiers>
     <user_identifier segment_type="External">
-      <id_type desc="Additional">02</id_type>
+      <id_type desc="MIT ID">02</id_type>
       <value></value>
       <status>ACTIVE</status>
     </user_identifier>

--- a/patronload/patron.py
+++ b/patronload/patron.py
@@ -80,7 +80,7 @@ def populate_common_fields(
         patron_template.emails.clear()  # type: ignore[union-attr]
 
     for user_identifier in patron_template.find_all("user_identifier"):
-        if user_identifier.find("id_type", desc="Additional"):
+        if user_identifier.find("id_type", desc="MIT ID"):
             user_identifier.value.string = patron_dict["MIT_ID"] or ""
         elif user_identifier.find("id_type", desc="Barcode"):
             if patron_dict["LIBRARY_ID"] and patron_dict["LIBRARY_ID"] != "NONE":

--- a/tests/fixtures/staff_patrons.xml
+++ b/tests/fixtures/staff_patrons.xml
@@ -62,7 +62,7 @@
         <is_researcher>false</is_researcher>
         <user_identifiers>
             <user_identifier segment_type="External">
-                <id_type desc="Additional">02</id_type>
+                <id_type desc="MIT ID">02</id_type>
                 <value>444444444</value>
                 <status>ACTIVE</status>
             </user_identifier>
@@ -138,7 +138,7 @@
         <is_researcher>false</is_researcher>
         <user_identifiers>
             <user_identifier segment_type="External">
-                <id_type desc="Additional">02</id_type>
+                <id_type desc="MIT ID">02</id_type>
                 <value>666666666</value>
                 <status>ACTIVE</status>
             </user_identifier>

--- a/tests/fixtures/student_patrons.xml
+++ b/tests/fixtures/student_patrons.xml
@@ -67,7 +67,7 @@
         <is_researcher />
         <user_identifiers>
             <user_identifier segment_type="External">
-                <id_type desc="Additional">02</id_type>
+                <id_type desc="MIT ID">02</id_type>
                 <value>333333333</value>
                 <status>ACTIVE</status>
             </user_identifier>
@@ -145,7 +145,7 @@
         <is_researcher />
         <user_identifiers>
             <user_identifier segment_type="External">
-                <id_type desc="Additional">02</id_type>
+                <id_type desc="MIT ID">02</id_type>
                 <value>555555555</value>
                 <status>ACTIVE</status>
             </user_identifier>


### PR DESCRIPTION
### What does this PR do?

Changes the description attribute of the '02' `<id_type>` element from 'Additional' to 'MIT ID' in the XML templates used to create patron records to ingest into Alma.

### Helpful background context

In Alma the '02' identifier type 'Additional' was renamed to 'MIT ID'. This PR makes it clear in the code that it is the MIT ID which is being mapped to the '02' identifier type in Alma, and likewise that the '02' identifier type in Alma is now named 'MIT ID'
see https://mitlibraries.atlassian.net/browse/ENSY-139 for more information

### How can a reviewer manually see the effects of these changes?

Follow instructions in readme.md to test in `stage` environment. Confirm that XML files deposited in S3 have correct id_type description 'MIT ID'

### Includes new or updated dependencies?

NO

### What are the relevant tickets?
https://mitlibraries.atlassian.net/browse/ENSY-154

### Developer

- [x] All new ENV is documented in README (or there is none)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines
      (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
